### PR TITLE
Feature detections

### DIFF
--- a/module/detector.py
+++ b/module/detector.py
@@ -30,6 +30,12 @@ class Detection(JSONSerializable):
         if kwargs:
             self.__dict__.update(kwargs)
 
+        log_handler = logging.StreamHandler()
+        log_handler.setFormatter(logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
     def __repr__(self) -> str:
         return f"Detection({self.__dict__})"
 
@@ -75,11 +81,11 @@ class Detection(JSONSerializable):
                 # If minutes since is greater than 24 hours don't go beyond that
                 # TODO: Convert 60*24 to a detector configuration item
                 if minutes_since > catchup_period:
-                    print(
+                    self.logger.info(
                         f"Adjusting lookbehind for {self.name} from {self.lookbehind} to {math.ceil(self.lookbehind+catchup_period)}")
                     self.lookbehind = math.ceil(self.lookbehind+catchup_period)
                 elif minutes_since > self.lookbehind:
-                    print(
+                    self.logger.info(
                         f"Minutes since is {minutes_since} which is greater than {self.lookbehind}.  Adjusting lookbehind for {self.name} from {self.lookbehind} to {math.ceil(self.lookbehind+minutes_since)}")
                     self.lookbehind = math.ceil(self.lookbehind+minutes_since)
 
@@ -1741,7 +1747,6 @@ class Detector(Process):
                             scroll_size = 0
 
                         # Scroll
-                        self.logger.info(f"{scroll_size}")
                         while (scroll_size > 0):
                             self.logger.info(
                                 f"{detection.name} ({detection.uuid}) - Scrolling Elasticsearch results...")

--- a/module/detector.py
+++ b/module/detector.py
@@ -638,6 +638,9 @@ class Detector(Process):
         start_execution_timer = datetime.datetime.utcnow()
         query_time = 0
 
+        # TODO - Add message and data_source as default signature fields
+        # TODO - Add data_source as a default field_mapping
+
         elastic = Elastic(
             _input['config'], field_mapping, credential, signature_fields=signature_fields)
 

--- a/module/detector.py
+++ b/module/detector.py
@@ -1718,7 +1718,8 @@ class Detector(Process):
                                     f"{detection.name} ({detection.uuid}) - Found {len(res['hits']['hits'])} detection hits.")
                                 # Parse the events and extract observables, tags, signature the event
                                 docs += elastic.parse_events(
-                                    res['hits']['hits'], title=detection.name, signature_values=[detection.detection_id], risk_score=detection.risk_score)
+                                    res['hits']['hits'], title=detection.name, signature_values=[detection.detection_id], risk_score=detection.risk_score,
+                                    time_to_detect=True)
 
                             scroll_size = len(res['hits']['hits'])
 

--- a/module/detector.py
+++ b/module/detector.py
@@ -1735,7 +1735,8 @@ class Detector(Process):
 
                             # Parse the events and extract observables, tags, signature the event
                             docs += elastic.parse_events(
-                                res['hits']['hits'], title=detection.name, signature_values=[detection.detection_id], risk_score=detection.risk_score)
+                                res['hits']['hits'], title=detection.name, signature_values=[detection.detection_id], risk_score=detection.risk_score,
+                                time_to_detect=True)
                         else:
                             scroll_size = 0
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -96,8 +96,9 @@ class Event(JSONSerializable):
         self.input_uuid = None
         self.metrics = {
             'agent_pickup_time': None,
-            'agent_bulk_start': None,
+            'agent_bulk_start': None
         }
+        self.time_to_detect = None
 
 
     def get_nested_field(self, message, field):

--- a/utils/elasticsearch.py
+++ b/utils/elasticsearch.py
@@ -166,7 +166,8 @@ class Elastic(Process):
         return observables
 
 
-    def parse_events(self, hits, title=None, signature_values=[], risk_score=None):
+    def parse_events(self, hits, title=None, signature_values=[], risk_score=None,
+                     time_to_detect=False):
         '''
         Parses events pulled from Elasticsearch and formats them 
         into a JSON array that fits the expected input of the REST API
@@ -223,6 +224,12 @@ class Elastic(Process):
             # Remove duplicate tags
             event.tags = [tag for tag in event.tags if tag not in ['',None,'-']]
             event.tags = list(set(event.tags))
+
+            if time_to_detect:
+                now = datetime.datetime.utcnow().isoformat()
+                if hasattr(event, 'original_date'):
+                    original_date = datetime.datetime.strptime(event.original_date, '%Y-%m-%dT%H:%M:%S')
+                    event.time_to_detect = (now - original_date).total_seconds()
 
             events.append(event)
         

--- a/utils/elasticsearch.py
+++ b/utils/elasticsearch.py
@@ -226,9 +226,9 @@ class Elastic(Process):
             event.tags = list(set(event.tags))
 
             if time_to_detect:
-                now = datetime.datetime.utcnow().isoformat()
+                now = datetime.datetime.utcnow()
                 if hasattr(event, 'original_date'):
-                    original_date = datetime.datetime.strptime(event.original_date, '%Y-%m-%dT%H:%M:%S')
+                    original_date = datetime.datetime.strptime(event.original_date, '%Y-%m-%dT%H:%M:%S.%f')
                     event.time_to_detect = (now - original_date).total_seconds()
 
             events.append(event)
@@ -281,6 +281,10 @@ class Elastic(Process):
                         logger.info(f"Found {len(res['hits']['hits'])} alerts.")
                         events += self.parse_events(res['hits']['hits'])
                     scroll_size = len(res['hits']['hits'])
+
+            # Clear the scroll window
+            if scroll_id:
+                self.conn.clear_scroll(scroll_id = scroll_id)
 
             return events
 


### PR DESCRIPTION
- Adds a `time_to_detect` field to Detections trigger by a match rule.  Requires that the source input have an `original_date_field` set.
- Fixes issues where the Detection engine would flood Opensearch/Elasticsearch with scroll contexts and not clean them up
- Fixed some logging issues