### PR TITLE
Allow Agents to bulk update detection stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ plugins/*.py
 
 .vscode/
 
-field_settings/*.db
+field_settings/*.db*
 
 test_base_rule.py
 

--- a/module/detector.py
+++ b/module/detector.py
@@ -147,7 +147,7 @@ class Detector(Process):
     Detection rules that return matches are sent to the API as Events
     '''
 
-    def __init__(self, config, agent=None, log_level='ERROR', *args, **kwargs):
+    def __init__(self, config, agent=None, log_level='INFO', *args, **kwargs):
 
         super(Detector, self).__init__(*args, **kwargs)
 

--- a/module/detector.py
+++ b/module/detector.py
@@ -147,7 +147,7 @@ class Detector(Process):
     Detection rules that return matches are sent to the API as Events
     '''
 
-    def __init__(self, config, agent=None, log_level='INFO', *args, **kwargs):
+    def __init__(self, config, agent=None, log_level='ERROR', *args, **kwargs):
 
         super(Detector, self).__init__(*args, **kwargs)
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -285,6 +285,14 @@ class Agent(object):
         self.cache_ttl = 30 # Number of minutes an item should be in the cache
         self.detection_rules = []
         self.health_check_interval = 30 # Number of seconds between health checks
+        self.detection_rule_updates = Queue()
+        self._detection_bulk_updater = Thread(target=self.bulk_update_detections)
+        self._detection_bulk_updater.start()
+
+        # Periodically check to make sure the bulk updater is running
+        # if it is not, start it
+        self._detection_bulk_updater_checker = Thread(target=self.check_bulk_updater)
+        self._detection_bulk_updater_checker.start()
 
         # Set a role health state, 0 = disabled, 1 = degraded, 2 = healthy
         self.role_health = {
@@ -292,6 +300,19 @@ class Agent(object):
             'runner': 0,
             'poller': 0
         }
+
+    def check_bulk_updater(self):
+        '''
+        Checks to make sure the bulk updater is running
+        and if it is not, starts it
+        '''
+
+        while True:
+            if not self._detection_bulk_updater.is_alive():
+                self.logger.error('The detection bulk updater is not running, starting it again')
+                self._detection_bulk_updater = Thread(target=self.bulk_update_detections)
+                self._detection_bulk_updater.start()
+            time.sleep(5)
 
     def agent_ip(self):
         '''
@@ -458,10 +479,34 @@ class Agent(object):
         Updated a detection via PUT request to the API
         '''
 
-        payload = json.loads(json.dumps(payload, default=str))
-        response = self.call_mgmt_api(f"detection/{uuid}", data=payload, method='PUT')
+        self.detection_rule_updates.put({
+            'uuid': uuid,
+            **payload
+        })
+
+        # DEPRECATED IN FAVOR OF BULK UPDATE
+        #payload = json.loads(json.dumps(payload, default=str))
+        #response = self.call_mgmt_api(f"detection/{uuid}", data=payload, method='PUT')
+        #if response and response.status_code != 200:
+        #    self.logger.error(f"Failed to update detection {uuid}. API response code {response.status_code}, {response.text}")
+
+
+    def bulk_update_detections(self):
+        '''
+        If the detection_rule_updates queue is not empty and there
+        are more than 10 items in the queue, bulk update the detections
+        '''
+
+        payload = []
+        
+        while not self.detection_rule_updates.empty() and len(payload) < 10:
+            payload.append(self.detection_rule_updates.get())
+
+        response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
         if response and response.status_code != 200:
-            self.logger.error(f"Failed to update detection {uuid}. API response code {response.status_code}, {response.text}")
+            self.logger.error(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+
+        time.sleep(1)
 
     
     def check_intel_list_values(self, list_uuid, values):

--- a/utils/base.py
+++ b/utils/base.py
@@ -502,9 +502,11 @@ class Agent(object):
             payload = []
 
             print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
-            pass
+            
 
             time.sleep(1)
+
+            pass
 
     
     def check_intel_list_values(self, list_uuid, values):

--- a/utils/base.py
+++ b/utils/base.py
@@ -497,7 +497,7 @@ class Agent(object):
         are more than 50 items in the queue, bulk update the detections
         '''
 
-        while self._detection_bulk_updater.is_alive():
+        while True:
             payload = []
         
             while not self.detection_rule_updates.empty() and len(payload) < 50:
@@ -509,6 +509,8 @@ class Agent(object):
                 response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
                 if response and response.status_code != 200:
                     self.logger.error(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+            else:
+                self.logger.debug("No detections to update")
 
             time.sleep(1)
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -245,7 +245,7 @@ class Agent(object):
         self.access_token = os.getenv('ACCESS_TOKEN')
         self.console_url = os.getenv('CONSOLE_URL')
         self.ip = self.agent_ip()
-        self.VERSION_NUMBER = "2024.01.15-rc0"
+        self.VERSION_NUMBER = "2024.01.15-rc1"
 
         log_levels = {
             'DEBUG': logging.DEBUG,

--- a/utils/base.py
+++ b/utils/base.py
@@ -514,9 +514,9 @@ class Agent(object):
         while True:
             payload = []
 
-            if self.detection_rule_updates.qsize() >= 25 or (datetime.datetime.now() - self.last_event_update_insert).seconds > 3:
+            if self.detection_rule_updates.qsize() >= 10 or (datetime.datetime.now() - self.last_event_update_insert).seconds > 1:
 
-                while not self.detection_rule_updates.empty() and len(payload) < 25:
+                while not self.detection_rule_updates.empty() and len(payload) < 10:
                     payload.append(self.detection_rule_updates.get())
 
             if len(payload) > 0:

--- a/utils/base.py
+++ b/utils/base.py
@@ -499,7 +499,7 @@ class Agent(object):
 
         payload = []
         
-        while not self.detection_rule_updates.empty() and len(payload) < 10:
+        while not self.detection_rule_updates.empty() and len(payload) < 25:
             payload.append(self.detection_rule_updates.get())
 
         response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')

--- a/utils/base.py
+++ b/utils/base.py
@@ -508,10 +508,13 @@ class Agent(object):
 
             if len(payload) > 0:
 
-                self.logger.info(f"Updating {len(payload)} detections")
-                response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
-                if response and response.status_code != 200:
-                    print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+                try:
+                    print(f"Updating {len(payload)} detections")
+                    response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
+                    if response and response.status_code != 200:
+                        print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+                except Exception as e:
+                    print(f"Failed to bulk update detections. {str(e)}")
             else:
                 print("No detections to update")
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -516,7 +516,7 @@ class Agent(object):
 
             if self.detection_rule_updates.qsize() >= 10 or (datetime.datetime.now() - self.last_event_update_insert).seconds > 1:
 
-                while not self.detection_rule_updates.empty() and len(payload) < 10:
+                while not self.detection_rule_updates.empty() and len(payload) < 50:
                     payload.append(self.detection_rule_updates.get())
 
             if len(payload) > 0:

--- a/utils/base.py
+++ b/utils/base.py
@@ -494,12 +494,12 @@ class Agent(object):
     def bulk_update_detections(self):
         '''
         If the detection_rule_updates queue is not empty and there
-        are more than 10 items in the queue, bulk update the detections
+        are more than 50 items in the queue, bulk update the detections
         '''
 
         payload = []
         
-        while not self.detection_rule_updates.empty() and len(payload) < 25:
+        while not self.detection_rule_updates.empty() and len(payload) < 50:
             payload.append(self.detection_rule_updates.get())
 
         response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')

--- a/utils/base.py
+++ b/utils/base.py
@@ -502,11 +502,8 @@ class Agent(object):
             payload = []
 
             print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
-            
 
             time.sleep(1)
-
-            pass
 
     
     def check_intel_list_values(self, list_uuid, values):

--- a/utils/base.py
+++ b/utils/base.py
@@ -287,6 +287,7 @@ class Agent(object):
         self.health_check_interval = 30 # Number of seconds between health checks
         self.detection_rule_updates = Queue()
         self._detection_bulk_updater = Thread(target=self.bulk_update_detections)
+        self.logger.info("Starting bulk detection rule updater")
         self._detection_bulk_updater.start()
 
         # Periodically check to make sure the bulk updater is running

--- a/utils/base.py
+++ b/utils/base.py
@@ -501,28 +501,10 @@ class Agent(object):
         while True:
             payload = []
 
-            try:
-                print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
+            print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
+            pass
 
-                time.sleep(1)
-            
-                while not self.detection_rule_updates.empty() and len(payload) < 50:
-                    payload.append(self.detection_rule_updates.get())
-
-                if len(payload) > 0:
-
-                    
-                        print(f"Updating {len(payload)} detections")
-                        response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
-                        if response and response.status_code != 200:
-                            print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
-                    
-                else:
-                    print("No detections to update")
-            except Exception as e:
-                print(f"Failed to bulk update detections. {str(e)}")
-
-            time.sleep(10)
+            time.sleep(1)
 
     
     def check_intel_list_values(self, list_uuid, values):

--- a/utils/base.py
+++ b/utils/base.py
@@ -516,7 +516,7 @@ class Agent(object):
 
             if self.detection_rule_updates.qsize() >= 10 or (datetime.datetime.now() - self.last_event_update_insert).seconds > 1:
 
-                while not self.detection_rule_updates.empty() and len(payload) < 50:
+                while not self.detection_rule_updates.empty() or len(payload) < 50:
                     payload.append(self.detection_rule_updates.get())
 
             if len(payload) > 0:

--- a/utils/base.py
+++ b/utils/base.py
@@ -499,6 +499,8 @@ class Agent(object):
 
         while True:
             payload = []
+
+            print("Checking for detections to update")
         
             while not self.detection_rule_updates.empty() and len(payload) < 50:
                 payload.append(self.detection_rule_updates.get())
@@ -508,11 +510,11 @@ class Agent(object):
                 self.logger.info(f"Updating {len(payload)} detections")
                 response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
                 if response and response.status_code != 200:
-                    self.logger.error(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+                    print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
             else:
-                self.logger.debug("No detections to update")
+                print("No detections to update")
 
-            time.sleep(1)
+            time.sleep(10)
 
     
     def check_intel_list_values(self, list_uuid, values):

--- a/utils/base.py
+++ b/utils/base.py
@@ -501,22 +501,26 @@ class Agent(object):
         while True:
             payload = []
 
-            print("Checking for detections to update")
-        
-            while not self.detection_rule_updates.empty() and len(payload) < 50:
-                payload.append(self.detection_rule_updates.get())
+            try:
+                print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
 
-            if len(payload) > 0:
+                time.sleep(1)
+            
+                while not self.detection_rule_updates.empty() and len(payload) < 50:
+                    payload.append(self.detection_rule_updates.get())
 
-                try:
-                    print(f"Updating {len(payload)} detections")
-                    response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
-                    if response and response.status_code != 200:
-                        print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
-                except Exception as e:
-                    print(f"Failed to bulk update detections. {str(e)}")
-            else:
-                print("No detections to update")
+                if len(payload) > 0:
+
+                    
+                        print(f"Updating {len(payload)} detections")
+                        response = self.call_mgmt_api('detection/_bulk_update_stats', data={'detections': payload}, method='PUT')
+                        if response and response.status_code != 200:
+                            print(f"Failed to bulk update detections. API response code {response.status_code}, {response.text}")
+                    
+                else:
+                    print("No detections to update")
+            except Exception as e:
+                print(f"Failed to bulk update detections. {str(e)}")
 
             time.sleep(10)
 

--- a/utils/base.py
+++ b/utils/base.py
@@ -286,7 +286,7 @@ class Agent(object):
         self.detection_rules = []
         self.health_check_interval = 30 # Number of seconds between health checks
         self.detection_rule_updates = Queue()
-        self._detection_bulk_updater = Thread(target=self.bulk_update_detections)
+        self._detection_bulk_updater = Thread(target=self.bulk_update_detections, args=(self.detection_rule_updates,))
         self.logger.info("Starting bulk detection rule updater")
         self._detection_bulk_updater.start()
 
@@ -492,7 +492,7 @@ class Agent(object):
         #    self.logger.error(f"Failed to update detection {uuid}. API response code {response.status_code}, {response.text}")
 
 
-    def bulk_update_detections(self):
+    def bulk_update_detections(self, detection_queue):
         '''
         If the detection_rule_updates queue is not empty and there
         are more than 50 items in the queue, bulk update the detections
@@ -501,7 +501,7 @@ class Agent(object):
         while True:
             payload = []
 
-            print(f"Checking for detections to update - Queue Size: {self.detection_rule_updates.qsize()}")
+            print(f"Checking for detections to update - Queue Size: {detection_queue.qsize()}")
 
             time.sleep(1)
 

--- a/utils/elasticsearch.py
+++ b/utils/elasticsearch.py
@@ -14,7 +14,7 @@ from .base import Event
 
 class Elastic(Process):
 
-    def __init__(self, config, field_mapping, credentials, signature_fields=[], input_uuid=None, timeout=30):
+    def __init__(self, config, field_mapping, credentials, signature_fields=[], input_uuid=None, timeout=60):
         ''' 
         Initializes a new Elasticsearch poller object
         which pushes information to the api


### PR DESCRIPTION
Allow Agents to bulk update detection stats by calling the `/api/v2.0/detections/_bulk_update_stats` endpoint.  Each detection update should be a JSON document inside the `detections` list.  Example:

```json
{
  "detections": [
    {
      "uuid": "8a7ae672-4cb7-4db8-a056-3c36079b6c7a",
      "last_run": "2024-01-15T19:29:03",
      "last_assessed": "2024-01-15T19:29:03",
      "average_hits_per_day": 36,
      "hits": 5,
      "time_taken": 300,
      "query_time_taken": 36,
      "assess_rule": false,
      "average_query_time": 168,
      "hits_over_time": "",
      "field_metrics": []
    },
    {
      "uuid": "a7cc370f-3895-42cb-b11f-3a1e08b85db8",
      "last_run": "2024-01-15T19:29:03",
      "hits": 3,
      "query_time_taken": 30
    },
    {
      "uuid": "a7cc370f-3895-42cb-b11f-3a1e08b85db8",
      "last_run": "2024-01-15T19:29:03",
      "hits": 3,
      "query_time_taken": 95
    }
  ]
}
```